### PR TITLE
댓글 CRUD 기능 서비스 로직 작성

### DIFF
--- a/src/main/java/org/kcsmini2/ojeommo/board/service/GatherBoardServiceImpl.java
+++ b/src/main/java/org/kcsmini2/ojeommo/board/service/GatherBoardServiceImpl.java
@@ -11,7 +11,7 @@ import org.kcsmini2.ojeommo.board.repository.BoardRepository;
 import org.kcsmini2.ojeommo.board.repository.GatherBoardRepository;
 import org.kcsmini2.ojeommo.category.entity.Category;
 import org.kcsmini2.ojeommo.category.repository.CategoryRepository;
-import org.kcsmini2.ojeommo.comment.CommentRepository;
+import org.kcsmini2.ojeommo.comment.repository.CommentRepository;
 import org.kcsmini2.ojeommo.member.data.PartyRepository;
 import org.kcsmini2.ojeommo.member.data.dto.MemberDTO;
 import org.kcsmini2.ojeommo.member.data.entity.Member;
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 

--- a/src/main/java/org/kcsmini2/ojeommo/comment/CommentRepository.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/CommentRepository.java
@@ -1,8 +1,0 @@
-package org.kcsmini2.ojeommo.comment;
-
-import org.kcsmini2.ojeommo.comment.data.entity.Comment;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CommentRepository extends JpaRepository<Comment,Long> {
-
-}

--- a/src/main/java/org/kcsmini2/ojeommo/comment/data/dto/request/CommentCreateRequestDTO.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/data/dto/request/CommentCreateRequestDTO.java
@@ -1,0 +1,30 @@
+package org.kcsmini2.ojeommo.comment.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.kcsmini2.ojeommo.board.data.entity.Board;
+import org.kcsmini2.ojeommo.comment.data.entity.Comment;
+import org.kcsmini2.ojeommo.member.data.entity.Member;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CommentCreateRequestDTO {
+    protected Long boardId;
+    protected String content;
+
+    public Comment toEntity(Member author, Board board) {
+        return Comment.builder()
+                .author(author)
+                .board(board)
+                .content(content)
+                .build();
+    }
+}
+
+
+
+

--- a/src/main/java/org/kcsmini2/ojeommo/comment/data/dto/request/CommentUpdateRequestDTO.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/data/dto/request/CommentUpdateRequestDTO.java
@@ -1,0 +1,30 @@
+package org.kcsmini2.ojeommo.comment.data.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.kcsmini2.ojeommo.board.data.entity.Board;
+import org.kcsmini2.ojeommo.comment.data.entity.Comment;
+import org.kcsmini2.ojeommo.member.data.entity.Member;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CommentUpdateRequestDTO {
+    protected Long commentId;
+    protected String content;
+
+    public Comment toEntity(Member author, Board board) {
+        return Comment.builder()
+                .author(author)
+                .board(board)
+                .content(content)
+                .build();
+    }
+}
+
+
+
+

--- a/src/main/java/org/kcsmini2/ojeommo/comment/data/dto/response/CommentDetailResponseDTO.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/data/dto/response/CommentDetailResponseDTO.java
@@ -1,0 +1,27 @@
+package org.kcsmini2.ojeommo.comment.data.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.kcsmini2.ojeommo.comment.data.entity.Comment;
+
+@Getter
+@NoArgsConstructor
+public class CommentDetailResponseDTO {
+
+    String content;
+    String authorId;
+
+    @Builder
+    protected CommentDetailResponseDTO(String content, String authorId) {
+        this.content = content;
+        this.authorId = authorId;
+    }
+
+    public static CommentDetailResponseDTO from(Comment comment) {
+        return CommentDetailResponseDTO.builder()
+                .content(comment.getContent())
+                .authorId(comment.getAuthor().getId())
+                .build();
+    }
+}

--- a/src/main/java/org/kcsmini2/ojeommo/comment/data/entity/Comment.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/data/entity/Comment.java
@@ -2,12 +2,18 @@ package org.kcsmini2.ojeommo.comment.data.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.kcsmini2.ojeommo.board.data.entity.Board;
+import org.kcsmini2.ojeommo.comment.data.dto.request.CommentUpdateRequestDTO;
 import org.kcsmini2.ojeommo.member.data.entity.Member;
 
 @Entity (name= "comment")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+        @Index(name = "idx__table", columnList = "board_id")
+})
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,10 +21,12 @@ public class Comment {
 
     @JoinColumn(name = "author_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member author;
 
     @JoinColumn(name = "board_id")
     @ManyToOne
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Board board;
 
     @Column
@@ -29,5 +37,14 @@ public class Comment {
         this.author = author;
         this.board = board;
         this.content = content;
+    }
+
+    public Comment update(CommentUpdateRequestDTO requestDTO) {
+        this.content = requestDTO.getContent();
+        return this;
+    }
+
+    public boolean isWrongAuthor(Member requester) {
+        return !this.author.equals(requester);
     }
 }

--- a/src/main/java/org/kcsmini2/ojeommo/comment/repository/CommentRepository.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package org.kcsmini2.ojeommo.comment.repository;
+
+import org.kcsmini2.ojeommo.board.data.entity.Board;
+import org.kcsmini2.ojeommo.comment.data.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Page<Comment> findByBoard(Pageable pageable, Board board);
+}

--- a/src/main/java/org/kcsmini2/ojeommo/comment/service/CommentService.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/service/CommentService.java
@@ -1,0 +1,22 @@
+package org.kcsmini2.ojeommo.comment.service;
+
+import org.kcsmini2.ojeommo.comment.data.dto.request.CommentCreateRequestDTO;
+import org.kcsmini2.ojeommo.comment.data.dto.request.CommentUpdateRequestDTO;
+import org.kcsmini2.ojeommo.comment.data.dto.response.CommentDetailResponseDTO;
+import org.kcsmini2.ojeommo.member.data.dto.MemberDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public interface CommentService {
+    void createComment(CommentCreateRequestDTO requestDTO, MemberDTO memberDTO);
+
+    Page<CommentDetailResponseDTO> readComments(Long boardId, Pageable pageable, MemberDTO memberDTO);
+
+    void updateComment(CommentUpdateRequestDTO requestDTO, MemberDTO memberDTO);
+
+    void deleteComment(Long boardId, MemberDTO memberDTO);
+
+}

--- a/src/main/java/org/kcsmini2/ojeommo/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/kcsmini2/ojeommo/comment/service/CommentServiceImpl.java
@@ -1,0 +1,71 @@
+package org.kcsmini2.ojeommo.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.kcsmini2.ojeommo.board.data.entity.Board;
+import org.kcsmini2.ojeommo.board.repository.BoardRepository;
+import org.kcsmini2.ojeommo.comment.data.dto.request.CommentCreateRequestDTO;
+import org.kcsmini2.ojeommo.comment.data.dto.request.CommentUpdateRequestDTO;
+import org.kcsmini2.ojeommo.comment.data.dto.response.CommentDetailResponseDTO;
+import org.kcsmini2.ojeommo.comment.data.entity.Comment;
+import org.kcsmini2.ojeommo.comment.repository.CommentRepository;
+import org.kcsmini2.ojeommo.member.data.dto.MemberDTO;
+import org.kcsmini2.ojeommo.member.data.entity.Member;
+import org.kcsmini2.ojeommo.member.repository.MemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+/**
+ * 작성자: 김태민
+ * <p>
+ * 설명: 댓글의 CRUD 기능을 처리하는 서비스 계층
+ * <p>
+ * 최종 수정 일자: 2023.08.03
+ */
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final MemberRepository memberRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+
+    @Override
+    public void createComment(CommentCreateRequestDTO requestDTO, MemberDTO memberDTO) {
+        Member author = memberRepository.getReferenceById(memberDTO.getId());
+        Board board = boardRepository.getReferenceById(requestDTO.getBoardId());
+        Comment newComment = requestDTO.toEntity(author, board);
+        commentRepository.save(newComment);
+    }
+
+    @Override
+    public Page<CommentDetailResponseDTO> readComments(Long boardId, Pageable pageable, MemberDTO memberDTO) {
+        Board board = boardRepository.getReferenceById(boardId);
+        Page<Comment> foundComments =  commentRepository.findByBoard(pageable, board);
+        return foundComments.map(CommentDetailResponseDTO::from);
+    }
+
+    @Override
+    public void updateComment(CommentUpdateRequestDTO requestDTO, MemberDTO memberDTO) {
+        Member requester = memberRepository.getReferenceById(memberDTO.getId());
+        Comment foundComment = commentRepository.findById(requestDTO.getCommentId())
+                .orElseThrow(() -> new RuntimeException("해당하는 ID의 댓글이 존재하지 않습니다."));
+        if (foundComment.isWrongAuthor(requester)) {
+            throw new RuntimeException("요청자와 작성자가 다릅니다.");
+        }
+        foundComment.update(requestDTO);
+    }
+
+    @Override
+    public void deleteComment(Long commentId, MemberDTO memberDTO) {
+        Member requester = memberRepository.getReferenceById(memberDTO.getId());
+        Comment foundComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("해당하는 ID의 댓글이 존재하지 않습니다."));
+        if (foundComment.isWrongAuthor(requester)) {
+            throw new RuntimeException("요청자와 작성자가 다릅니다.");
+        }
+        commentRepository.delete(foundComment);
+    }
+
+
+}

--- a/src/main/java/org/kcsmini2/ojeommo/member/data/entity/Member.java
+++ b/src/main/java/org/kcsmini2/ojeommo/member/data/entity/Member.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 작성자: 김준연
@@ -73,7 +74,18 @@ public class Member{
         catch (Exception e) {
             return false;
         }
-
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/org/kcsmini2/ojeommo/member/data/entity/Member.java
+++ b/src/main/java/org/kcsmini2/ojeommo/member/data/entity/Member.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -64,7 +65,18 @@ public class Member{
         catch (Exception e) {
             return false;
         }
-
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }


### PR DESCRIPTION
댓글 관련 CRUD 로직을 추가했습니다. 

- 요청자와 작성자가 같은지 확인하기 위해 Member 엔티티에 equals 메서드를 재정의했습니다.
- 게시글별로 댓글을 조회할 수 있도록 댓글에 다음과 같이 인덱스를 추가했습니다. `@Index(name = "idx__table", columnList = "board_id")`